### PR TITLE
bugfix: set gradient accumulation normalizer to num micro batches

### DIFF
--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -359,6 +359,8 @@ class DataParallelPPOActor(BasePPOActor):
                     self.gradient_accumulation = self.config.ppo_mini_batch_size // self.config.ppo_micro_batch_size_per_gpu
                     num_micro_batches = mini_batch.batch.batch_size[0] // self.config.ppo_micro_batch_size_per_gpu
                     micro_batches = data.select(select_keys, non_tensor_select_keys).chunk(num_micro_batches)
+                    if self.config.num_gradient_updates_per_batch > 0:
+                        self.gradient_accumulation = num_micro_batches
                 elif self.config.use_dynamic_bsz:
                     max_token_len = self.config.ppo_max_token_len_per_gpu * self.ulysses_sequence_parallel_size
                     micro_batches, _ = rearrange_micro_batches(batch=mini_batch, max_token_len=max_token_len)
@@ -366,6 +368,10 @@ class DataParallelPPOActor(BasePPOActor):
                     self.gradient_accumulation = self.config.ppo_mini_batch_size // self.config.ppo_micro_batch_size_per_gpu
                     # split batch into micro_batches
                     micro_batches = mini_batch.split(self.config.ppo_micro_batch_size_per_gpu)
+                    if self.config.num_gradient_updates_per_batch > 0:
+                        self.gradient_accumulation = len(micro_batches)
+
+                print(f"PPO epoch {epoch} batch {batch_idx} has {len(micro_batches)} micro_batches. gradient_accumulation={self.gradient_accumulation}")
 
                 self.actor_optimizer.zero_grad()
 


### PR DESCRIPTION
when `num_gradient_updates_per_batch > 0`, `gradient_accumulation` should be set to the number of micro batches for each mini batch